### PR TITLE
[layerzero oft] send some gas on dest chain when transfer OFT

### DIFF
--- a/tasks/solana/sendOFT.ts
+++ b/tasks/solana/sendOFT.ts
@@ -7,10 +7,10 @@ import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import bs58 from 'bs58'
 import { task } from 'hardhat/config'
 
-import { formatEid } from '@layerzerolabs/devtools'
+import { formatEid, makeBytes32 } from '@layerzerolabs/devtools'
 import { types } from '@layerzerolabs/devtools-evm-hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
-import { addressToBytes32 } from '@layerzerolabs/lz-v2-utilities'
+import { addressToBytes32, Options } from '@layerzerolabs/lz-v2-utilities'
 import { oft } from '@layerzerolabs/oft-v2-solana-sdk'
 
 import { deriveConnection, getExplorerTxLink, getLayerZeroScanLink } from './index'
@@ -72,6 +72,8 @@ task('lz:oft:solana:send', 'Send tokens from Solana to a target EVM chain')
             }
 
             const recipientAddressBytes32 = addressToBytes32(to)
+            // drop 1 x 10^13 wei gas = 0.00001 ETH on the dest EVM chain
+            const _options = Options.newOptions().addExecutorNativeDropOption(1e13, makeBytes32(to))
 
             const { nativeFee } = await oft.quote(
                 umi.rpc,
@@ -86,7 +88,7 @@ task('lz:oft:solana:send', 'Send tokens from Solana to a target EVM chain')
                     dstEid: toEid,
                     amountLd: BigInt(amount),
                     minAmountLd: 1n,
-                    options: Buffer.from(''),
+                    options: _options.toBytes(),
                     composeMsg: undefined,
                 },
                 {
@@ -107,7 +109,7 @@ task('lz:oft:solana:send', 'Send tokens from Solana to a target EVM chain')
                     dstEid: toEid,
                     amountLd: BigInt(amount),
                     minAmountLd: (BigInt(amount) * BigInt(9)) / BigInt(10),
-                    options: Buffer.from(''),
+                    options: _options.toBytes(),
                     composeMsg: undefined,
                     nativeFee,
                 },


### PR DESCRIPTION
Its quite straightforward as LayerZero support `NativeDropOption` to send gas with OFT: https://docs.layerzero.network/v2/developers/evm/protocol-gas-settings/options#lznativedrop-option

Tested with:

Base->Linea OFT transfer with 0.00005 ETH gas:
https://layerzeroscan.com/tx/0x9ea17316d6eccc90c4c7d53f708cac62ce40a36130776d0e0f083a59a289a17d

Linea->Solana OFT transfer with 0.002 SOL gas:
https://layerzeroscan.com/tx/0x1eb8050357df8ba95e5c90d704f09d94e7e1015f9be129aa94ed12ed3dfc35c4

Solana->Linea OFT transfer with 0.00001 ETH gas:
https://layerzeroscan.com/tx/3FNfVzwUzW1nBzBpTa15DEcDckLqn9e2FrdZ7i5sWJ6FnTyx4e9yQuqef58qtU1kniA1CdzbPk6NuvZMViPF2rmY

@iamkun @toprince 