### PR TITLE
Upgrade DVN security to 3/3: LayerZero Labs + Nethermind + Horizen

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,38 @@ oft: EaWXNTXSauuEWUyzBATCCbLfscNAgxS4bfQHnTGKeFXY
     - Sepolia: https://sepolia.etherscan.io/tx/0x1ffc9a118ef8fb9f769b8a066ea6f5e9081e5bc1743208df83bff63a5c72a109
 
 
+## Production Ownership & Access Control
+
+### EVM OFT Ownership
+
+All EVM OFT contracts have been transferred to WOO Network treasury multisig (Gnosis Safe) addresses:
+
+| Chain | Contract | Owner (Multisig) |
+|-------|----------|-----------------|
+| Ethereum | WooTokenOFTAdapter | `0x155eef9731aff5ae6cb2741f7bec0f005037acb0` |
+| Linea | WooTokenOFT | `0x1354fde75b51e388e79e9b721cf6fc9773ac8ac5` |
+| Base | WooTokenOFT | `0xc06e2968afd4a029d4623f9a5f534c45e5bf0bdf` |
+| zkSync | WooTokenOFT | `0x91ff1c154b72004d0591868ceb98efdc4023371b` |
+| Mantle | WooTokenOFT | `0x5cc24db3b7f0099d141a4bc96b4fddf9f5f3b614` |
+| Sonic | WooTokenOFT | `0x3d2f54bac9eb3bdb360bc3bab6e77243377a3586` |
+
+### EVM OFT Delegate
+
+Chi's developer address `0xc031C368b51c28266396273b0C6ce2489b00969d` has been set as the **delegate** on all EVM chains via LayerZero EndpointV2. This allows the delegate to call `setConfig()` (e.g. DVN changes, executor config) on behalf of the OApp without requiring multisig transactions for routine config operations.
+
+### Solana OFT Ownership
+
+The Solana OFT program (`woo98ny1QLULqdTzpNM8PiJpwfzL5MJ9pAmLw1rfvk7`) ownership is held by Chi's developer Solana address:
+
+| | Address |
+|---|---------|
+| Owner | `8ATsKQ16gNa3M9hXF7zAPvkjEREmzyhrXGHM6aKPPPDm` |
+| OFT Store | `8wX49KNNCPqfMUb8F1x3XipDEfqZnsCP5dDqxaxHjLCw` |
+
+As the owner, Chi can directly perform config operations (DVN changes, enforced options, etc.) for the Solana OFT without multisig.
+
+---
+
 ## Debugging the error on receiver side
 
 - https://scan-testnet.layerzero-api.com/v1/messages/tx/0x79bfff15f23ed6b309ee9f04321cb8a91f5b5515e32bb3e8396cc737620e9e03

--- a/layerzero.config.prod.ts
+++ b/layerzero.config.prod.ts
@@ -423,7 +423,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0xcd37ca043f8479064e10635020c65ffc005d36f6', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -431,7 +431,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0xcd37ca043f8479064e10635020c65ffc005d36f6', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -503,7 +503,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0xcd37ca043f8479064e10635020c65ffc005d36f6', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -511,7 +511,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0xcd37ca043f8479064e10635020c65ffc005d36f6', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -531,7 +531,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '0x9e059a54699a285714207b43b055483e78faac25',
-                            '0x658947bc7956aea0067a62cf87ab02ae199ef3f3',
+                            '0xcd37ca043f8479064e10635020c65ffc005d36f6',
                             '0xa7b5189bca84cd304d8553977c7c614329750d99',
                         ],
                         optionalDVNs: [],
@@ -543,7 +543,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '0x9e059a54699a285714207b43b055483e78faac25',
-                            '0x658947bc7956aea0067a62cf87ab02ae199ef3f3',
+                            '0xcd37ca043f8479064e10635020c65ffc005d36f6',
                             '0xa7b5189bca84cd304d8553977c7c614329750d99',
                         ],
                         optionalDVNs: [],
@@ -849,7 +849,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0xcd37ca043f8479064e10635020c65ffc005d36f6', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -857,7 +857,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0xcd37ca043f8479064e10635020c65ffc005d36f6', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1195,7 +1195,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0xcd37ca043f8479064e10635020c65ffc005d36f6', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1203,7 +1203,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0xcd37ca043f8479064e10635020c65ffc005d36f6', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1621,7 +1621,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0xcd37ca043f8479064e10635020c65ffc005d36f6', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1629,7 +1629,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0xcd37ca043f8479064e10635020c65ffc005d36f6', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },

--- a/layerzero.config.prod.ts
+++ b/layerzero.config.prod.ts
@@ -91,7 +91,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5', '0x380275805876ff19055ea900cdb2b46a94ecf20d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -99,7 +99,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5', '0x380275805876ff19055ea900cdb2b46a94ecf20d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -131,7 +131,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -139,7 +139,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -160,6 +160,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x589dEDbD617e0CBcB916A9223F4d1300c294236b',
                             '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5',
+                            '0x380275805876ff19055ea900cdb2b46a94ecf20d',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -171,6 +172,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x589dEDbD617e0CBcB916A9223F4d1300c294236b',
                             '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5',
+                            '0x380275805876ff19055ea900cdb2b46a94ecf20d',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -218,6 +220,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -229,6 +232,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -262,6 +266,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480',
                             '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b',
+                            '0x7fe673201724925b5c477d4e1a4bd3e954688cf5',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -273,6 +278,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480',
                             '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b',
+                            '0x7fe673201724925b5c477d4e1a4bd3e954688cf5',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -320,6 +326,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -331,6 +338,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -375,7 +383,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5', '0x380275805876ff19055ea900cdb2b46a94ecf20d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -383,7 +391,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5', '0x380275805876ff19055ea900cdb2b46a94ecf20d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -415,7 +423,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -423,7 +431,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -455,7 +463,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -463,7 +471,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -495,7 +503,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -503,7 +511,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -524,6 +532,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x9e059a54699a285714207b43b055483e78faac25',
                             '0x658947bc7956aea0067a62cf87ab02ae199ef3f3',
+                            '0xa7b5189bca84cd304d8553977c7c614329750d99',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -535,6 +544,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x9e059a54699a285714207b43b055483e78faac25',
                             '0x658947bc7956aea0067a62cf87ab02ae199ef3f3',
+                            '0xa7b5189bca84cd304d8553977c7c614329750d99',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -582,6 +592,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -593,6 +604,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -637,7 +649,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5', '0x380275805876ff19055ea900cdb2b46a94ecf20d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -645,7 +657,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5', '0x380275805876ff19055ea900cdb2b46a94ecf20d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -677,7 +689,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c', '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -685,7 +697,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c', '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -717,7 +729,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -725,7 +737,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -757,7 +769,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c', '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -765,7 +777,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c', '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -797,7 +809,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c', '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -805,7 +817,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c', '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -837,7 +849,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -845,7 +857,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -866,6 +878,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x620a9df73d2f1015ea75aea1067227f9013f5c51',
                             '0xb183c2b91cf76cad13602b32ada2fd273f19009c',
+                            '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -877,6 +890,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x620a9df73d2f1015ea75aea1067227f9013f5c51',
                             '0xb183c2b91cf76cad13602b32ada2fd273f19009c',
+                            '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -924,6 +938,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -935,6 +950,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -979,7 +995,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5', '0x380275805876ff19055ea900cdb2b46a94ecf20d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -987,7 +1003,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5', '0x380275805876ff19055ea900cdb2b46a94ecf20d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1019,7 +1035,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1027,7 +1043,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1059,7 +1075,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1067,7 +1083,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1099,7 +1115,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1107,7 +1123,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1139,7 +1155,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1147,7 +1163,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1179,7 +1195,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1187,7 +1203,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1219,7 +1235,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1227,7 +1243,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1259,7 +1275,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c', '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1267,7 +1283,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c', '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1288,6 +1304,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x28b6140ead70cb2fb669705b3598ffb4beaa060b',
                             '0xb19a9370d404308040a9760678c8ca28affbbb76',
+                            '0x7fe673201724925b5c477d4e1a4bd3e954688cf5',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1299,6 +1316,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x28b6140ead70cb2fb669705b3598ffb4beaa060b',
                             '0xb19a9370d404308040a9760678c8ca28affbbb76',
+                            '0x7fe673201724925b5c477d4e1a4bd3e954688cf5',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1346,6 +1364,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1357,6 +1376,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1401,7 +1421,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5', '0x380275805876ff19055ea900cdb2b46a94ecf20d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1409,7 +1429,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5', '0x380275805876ff19055ea900cdb2b46a94ecf20d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1441,7 +1461,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e', '0x54dd79f5ce72b51fcbbcb170dd01e32034323565'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1449,7 +1469,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e', '0x54dd79f5ce72b51fcbbcb170dd01e32034323565'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1481,7 +1501,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1489,7 +1509,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1521,7 +1541,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e', '0x54dd79f5ce72b51fcbbcb170dd01e32034323565'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1529,7 +1549,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e', '0x54dd79f5ce72b51fcbbcb170dd01e32034323565'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1561,7 +1581,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e', '0x54dd79f5ce72b51fcbbcb170dd01e32034323565'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1569,7 +1589,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e', '0x54dd79f5ce72b51fcbbcb170dd01e32034323565'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1601,7 +1621,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1609,7 +1629,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3', '0xa7b5189bca84cd304d8553977c7c614329750d99'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1641,7 +1661,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e', '0x54dd79f5ce72b51fcbbcb170dd01e32034323565'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1649,7 +1669,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e', '0x54dd79f5ce72b51fcbbcb170dd01e32034323565'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1681,7 +1701,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c', '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1689,7 +1709,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c', '0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1721,7 +1741,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1729,7 +1749,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76', '0x7fe673201724925b5c477d4e1a4bd3e954688cf5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1761,7 +1781,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e', '0x54dd79f5ce72b51fcbbcb170dd01e32034323565'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1769,7 +1789,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e', '0x54dd79f5ce72b51fcbbcb170dd01e32034323565'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1790,6 +1810,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x282b3386571f7f794450d5789911a9804fa346b4',
                             '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e',
+                            '0x54dd79f5ce72b51fcbbcb170dd01e32034323565',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1801,6 +1822,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '0x282b3386571f7f794450d5789911a9804fa346b4',
                             '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e',
+                            '0x54dd79f5ce72b51fcbbcb170dd01e32034323565',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1848,6 +1870,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1859,6 +1882,7 @@ const config: OAppOmniGraphHardhat = {
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
                             'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                            'HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,

--- a/layerzero.config.prod.ts
+++ b/layerzero.config.prod.ts
@@ -91,7 +91,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -99,7 +99,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -131,7 +131,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -139,7 +139,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -159,6 +159,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '0x589dEDbD617e0CBcB916A9223F4d1300c294236b',
+                            '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -169,6 +170,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '0x589dEDbD617e0CBcB916A9223F4d1300c294236b',
+                            '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -215,6 +217,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -225,6 +228,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -257,6 +261,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480',
+                            '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -267,6 +272,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480',
+                            '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -313,6 +319,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -323,6 +330,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -367,7 +375,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -375,7 +383,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -407,7 +415,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -415,7 +423,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -447,7 +455,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -455,7 +463,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -487,7 +495,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -495,7 +503,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -515,6 +523,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '0x9e059a54699a285714207b43b055483e78faac25',
+                            '0x658947bc7956aea0067a62cf87ab02ae199ef3f3',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -525,6 +534,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '0x9e059a54699a285714207b43b055483e78faac25',
+                            '0x658947bc7956aea0067a62cf87ab02ae199ef3f3',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -571,6 +581,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -581,6 +592,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -625,7 +637,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -633,7 +645,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -665,7 +677,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -673,7 +685,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -705,7 +717,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -713,7 +725,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -745,7 +757,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -753,7 +765,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -785,7 +797,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -793,7 +805,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -825,7 +837,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -833,7 +845,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -853,6 +865,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '0x620a9df73d2f1015ea75aea1067227f9013f5c51',
+                            '0xb183c2b91cf76cad13602b32ada2fd273f19009c',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -863,6 +876,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '0x620a9df73d2f1015ea75aea1067227f9013f5c51',
+                            '0xb183c2b91cf76cad13602b32ada2fd273f19009c',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -909,6 +923,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -919,6 +934,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -963,7 +979,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -971,7 +987,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1003,7 +1019,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1011,7 +1027,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1043,7 +1059,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1051,7 +1067,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1083,7 +1099,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1091,7 +1107,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1123,7 +1139,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1131,7 +1147,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1163,7 +1179,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1171,7 +1187,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1203,7 +1219,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1211,7 +1227,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1243,7 +1259,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1251,7 +1267,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1271,6 +1287,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '0x28b6140ead70cb2fb669705b3598ffb4beaa060b',
+                            '0xb19a9370d404308040a9760678c8ca28affbbb76',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1281,6 +1298,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '0x28b6140ead70cb2fb669705b3598ffb4beaa060b',
+                            '0xb19a9370d404308040a9760678c8ca28affbbb76',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1327,6 +1345,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1337,6 +1356,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1381,7 +1401,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1389,7 +1409,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b'],
+                        requiredDVNs: ['0x589dEDbD617e0CBcB916A9223F4d1300c294236b', '0xa59ba433ac34d2927232918ef5b2eaafcf130ba5'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1421,7 +1441,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1429,7 +1449,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1461,7 +1481,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1469,7 +1489,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480'],
+                        requiredDVNs: ['0x129ee430cb2ff2708ccaddbdb408a88fe4ffd480', '0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1501,7 +1521,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1509,7 +1529,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1541,7 +1561,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1549,7 +1569,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1581,7 +1601,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1589,7 +1609,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25'],
+                        requiredDVNs: ['0x9e059a54699a285714207b43b055483e78faac25', '0x658947bc7956aea0067a62cf87ab02ae199ef3f3'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1621,7 +1641,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1629,7 +1649,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1661,7 +1681,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1669,7 +1689,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51'],
+                        requiredDVNs: ['0x620a9df73d2f1015ea75aea1067227f9013f5c51', '0xb183c2b91cf76cad13602b32ada2fd273f19009c'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1701,7 +1721,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1709,7 +1729,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b'],
+                        requiredDVNs: ['0x28b6140ead70cb2fb669705b3598ffb4beaa060b', '0xb19a9370d404308040a9760678c8ca28affbbb76'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1741,7 +1761,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1749,7 +1769,7 @@ const config: OAppOmniGraphHardhat = {
                 receiveConfig: {
                     ulnConfig: {
                         confirmations: BigInt(15),
-                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4'],
+                        requiredDVNs: ['0x282b3386571f7f794450d5789911a9804fa346b4', '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e'],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                     },
@@ -1769,6 +1789,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '0x282b3386571f7f794450d5789911a9804fa346b4',
+                            '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1779,6 +1800,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '0x282b3386571f7f794450d5789911a9804fa346b4',
+                            '0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1825,6 +1847,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(32),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
@@ -1835,6 +1858,7 @@ const config: OAppOmniGraphHardhat = {
                         confirmations: BigInt(15),
                         requiredDVNs: [
                             '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                            'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
                         ],
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@layerzerolabs/lz-evm-messagelib-v2": "^3.0.12",
     "@layerzerolabs/lz-evm-protocol-v2": "^3.0.12",
     "@layerzerolabs/lz-evm-v1-0.7": "^3.0.12",
-    "@layerzerolabs/lz-solana-sdk-v2": "3.0.0",
+    "@layerzerolabs/lz-solana-sdk-v2": "^3.0.68",
     "@layerzerolabs/lz-v2-utilities": "^3.0.12",
     "@layerzerolabs/oapp-evm": "^0.3.0",
     "@layerzerolabs/oft-evm": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: ^3.0.12
         version: 3.0.18(@openzeppelin/contracts-upgradeable@5.1.0(@openzeppelin/contracts@5.1.0))(@openzeppelin/contracts@5.1.0)(hardhat-deploy@0.12.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@layerzerolabs/lz-solana-sdk-v2':
-        specifier: 3.0.0
-        version: 3.0.0(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)
+        specifier: ^3.0.68
+        version: 3.0.68(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)
       '@layerzerolabs/lz-v2-utilities':
         specifier: ^3.0.12
         version: 3.0.18
@@ -78,7 +78,7 @@ importers:
         version: 3.0.5(m4t2d3o6ulrntmpczi4vr6yxga)
       '@layerzerolabs/protocol-devtools-solana':
         specifier: ^4.0.7
-        version: 4.0.7(k67kjvmewxl2uheutlxyqujtmi)
+        version: 4.0.7(ftdsdl3eqw6hg273iinzxq7cge)
       '@layerzerolabs/solhint-config':
         specifier: ^3.0.12
         version: 3.0.18(typescript@5.7.2)
@@ -105,7 +105,7 @@ importers:
         version: 6.0.8(zv7flfvo3ufj3lgdegs4jcbjpi)
       '@layerzerolabs/ua-devtools-solana':
         specifier: ~4.1.0
-        version: 4.1.0(vouy6yru42fj6xxoh4lnbmwmca)
+        version: 4.1.0(2hnqceym4enum4kywvtggbtboq)
       '@metaplex-foundation/mpl-token-metadata':
         specifier: ^3.2.1
         version: 3.3.0(@metaplex-foundation/umi@0.9.2)
@@ -890,14 +890,8 @@ packages:
       yoga-layout-prebuilt:
         optional: true
 
-  '@layerzerolabs/lz-core@3.0.18':
-    resolution: {integrity: sha512-fA6MpGGtEj6ndke9BWpoEINm3PLslCtJuJP6YObq8fSHoiVRn99ku4SAvM05JherXgtPLQrmETri/xXHeOuylg==}
-
   '@layerzerolabs/lz-core@3.0.68':
     resolution: {integrity: sha512-ZDKa90/We3cggmm8aosoxrKjAZCFtWj+eMqt24qqolAjgaTxsG9YoW8HElNwM4CYI3CCuSZOTFjh14UT6iKsBA==}
-
-  '@layerzerolabs/lz-corekit-solana@3.0.18':
-    resolution: {integrity: sha512-dnic7VcibHd/uGNSWIPvZIF7vOfcF4rjcdILRbqJMRde/Cer0c0hK1Rft1/JKXbOIAe0sv4n4f7/PSa6rRzFXg==}
 
   '@layerzerolabs/lz-corekit-solana@3.0.68':
     resolution: {integrity: sha512-452OcBNYpwbUuHrcmOw4Z+LN/QWWfNqYXGQAsc8XD7x+qa26CBvPP1l8XHIdQnQdzlujhYZsVpCS85ZKbC3hqg==}
@@ -960,14 +954,8 @@ packages:
   '@layerzerolabs/lz-serdes@3.0.68':
     resolution: {integrity: sha512-N4htLgAcdQI5mxpl61J1N3PzaxeL3OMe6gDXR5pWBw9H+LapVUj96sbjfxeYnAVJwXt7EL0IQqJJEovOMTYrww==}
 
-  '@layerzerolabs/lz-solana-sdk-v2@3.0.0':
-    resolution: {integrity: sha512-sPvLXeQUO9QLpjOuWE7V+V8yfoI4E/NBYsH9lO2aPx0LYkQa+88ACgPq43B/zFROUD8238WuSb+doGrn3PKtJQ==}
-
   '@layerzerolabs/lz-solana-sdk-v2@3.0.68':
     resolution: {integrity: sha512-QuKhbsDH+peW4xDlbSul8Wkk9lWcdTWavQgbgmodWQ5JEUqRW3+LJ425djvJWBzR8B4UtJETyA2Uo3+qTVTzmQ==}
-
-  '@layerzerolabs/lz-utilities@3.0.18':
-    resolution: {integrity: sha512-6sGxPMCHT1+N+6BgpksSvy+YOKpebGNbtWgm1S//+wfQl4JyK95wrQ18TKphcnzqT0ZYbgYP6w41gRCSURhhkQ==}
 
   '@layerzerolabs/lz-utilities@3.0.68':
     resolution: {integrity: sha512-zxvqzkfggxA0tK86DCrZT/fchdSDXfM3wVWGO+g37WOf/mmcu/aE1AKLixtI4UaNWUDjT0w8QCIAacRZyOI4kA==}
@@ -1160,9 +1148,6 @@ packages:
     resolution: {integrity: sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==}
     engines: {node: '>=12.0.0'}
 
-  '@metaplex-foundation/beet-solana@0.3.1':
-    resolution: {integrity: sha512-tgyEl6dvtLln8XX81JyBvWjIiEcjTkUwZbrM5dIobTmoqMuGewSyk9CClno8qsMsFdB5T3jC91Rjeqmu/6xk2g==}
-
   '@metaplex-foundation/beet-solana@0.4.1':
     resolution: {integrity: sha512-/6o32FNUtwK8tjhotrvU/vorP7umBuRFvBZrC6XCk51aKidBHe5LPVPA5AjGPbV3oftMfRuXPNd9yAGeEqeCDQ==}
 
@@ -1178,13 +1163,6 @@ packages:
     resolution: {integrity: sha512-fd6JxfoLbj/MM8FG2x91KYVy1U6AjBQw4qjt7+Da3trzQaWnSaYHDcYRG/53xqfvZ9qofY1T2t53GXPlD87lnQ==}
     peerDependencies:
       '@metaplex-foundation/umi': '>= 0.8.2 < 1'
-
-  '@metaplex-foundation/rustbin@0.3.5':
-    resolution: {integrity: sha512-m0wkRBEQB/8krwMwKBvFugufZtYwMXiGHud2cTDAv+aGXK4M90y0Hx67/wpu+AqqoQfdV8VM9YezUOHKD+Z5kA==}
-
-  '@metaplex-foundation/solita@0.20.1':
-    resolution: {integrity: sha512-E2bHGzT6wA/sXWBLgJ50ZQNvukPnQlH6kRU6m6lmatJdEOjNWhR1lLI7ESIk/i4ZiSdHZkc/Q6ile8eIlXOzNQ==}
-    hasBin: true
 
   '@metaplex-foundation/umi-bundle-defaults@0.9.2':
     resolution: {integrity: sha512-kV3tfvgvRjVP1p9OFOtH+ibOtN9omVJSwKr0We4/9r45e5LTj+32su0V/rixZUkG1EZzzOYBsxhtIE0kIw/Hrw==}
@@ -2629,10 +2607,6 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
-  commander@5.1.0:
-    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
-    engines: {node: '>= 6'}
-
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -3366,10 +3340,6 @@ packages:
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
-
-  find-process@1.4.7:
-    resolution: {integrity: sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==}
-    hasBin: true
 
   find-replace@3.0.0:
     resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
@@ -5433,9 +5403,6 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
-  spok@1.5.5:
-    resolution: {integrity: sha512-IrJIXY54sCNFASyHPOY+jEirkiJ26JDqsGiI0Dvhwcnkl0PEWi1PSsrkYql0rzDw8LFVTcA7rdUCAJdE2HE+2Q==}
-
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -7385,24 +7352,7 @@ snapshots:
       react: 17.0.2
       yoga-layout-prebuilt: 1.10.0
 
-  '@layerzerolabs/lz-core@3.0.18': {}
-
   '@layerzerolabs/lz-core@3.0.68': {}
-
-  '@layerzerolabs/lz-corekit-solana@3.0.18(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@layerzerolabs/lz-core': 3.0.18
-      '@layerzerolabs/lz-utilities': 3.0.18(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
-      '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      bip39: 3.1.0
-      ed25519-hd-key: 1.3.0
-      tiny-invariant: 1.3.3
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - typescript
-      - utf-8-validate
 
   '@layerzerolabs/lz-corekit-solana@3.0.68(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)':
     dependencies:
@@ -7502,36 +7452,6 @@ snapshots:
 
   '@layerzerolabs/lz-serdes@3.0.68': {}
 
-  '@layerzerolabs/lz-solana-sdk-v2@3.0.0(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/sha2': 5.7.0
-      '@ethersproject/solidity': 5.7.0
-      '@layerzerolabs/lz-corekit-solana': 3.0.18(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
-      '@layerzerolabs/lz-definitions': 3.0.68
-      '@layerzerolabs/lz-v2-utilities': 3.0.18
-      '@metaplex-foundation/beet': 0.7.2
-      '@metaplex-foundation/beet-solana': 0.4.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@metaplex-foundation/solita': 0.20.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@solana/spl-token': 0.3.11(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)
-      '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      bn.js: 5.2.1
-      bs58: 5.0.0
-      ethereumjs-util: 7.1.5
-      tiny-invariant: 1.3.3
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - supports-color
-      - typescript
-      - utf-8-validate
-
   '@layerzerolabs/lz-solana-sdk-v2@3.0.68(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@layerzerolabs/lz-corekit-solana': 3.0.68(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
@@ -7558,29 +7478,6 @@ snapshots:
       - encoding
       - fastestsmallesttextencoderdecoder
       - supports-color
-      - typescript
-      - utf-8-validate
-
-  '@layerzerolabs/lz-utilities@3.0.18(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@initia/initia.js': 0.2.23(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
-      '@layerzerolabs/lz-definitions': 3.0.68
-      '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@ton/core': 0.59.0(@ton/crypto@3.3.0)
-      '@ton/crypto': 3.3.0
-      '@ton/ton': 15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)
-      aptos: 1.21.0
-      bip39: 3.1.0
-      ed25519-hd-key: 1.3.0
-      ethers: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      find-up: 5.0.0
-      memoizee: 0.4.17
-      winston: 3.17.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
       - typescript
       - utf-8-validate
 
@@ -7697,13 +7594,13 @@ snapshots:
       p-memoize: 4.0.4
       zod: 3.23.8
 
-  '@layerzerolabs/protocol-devtools-solana@4.0.7(k67kjvmewxl2uheutlxyqujtmi)':
+  '@layerzerolabs/protocol-devtools-solana@4.0.7(ftdsdl3eqw6hg273iinzxq7cge)':
     dependencies:
       '@layerzerolabs/devtools': 0.4.5(@ethersproject/bytes@5.7.0)(@layerzerolabs/io-devtools@0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8))(@layerzerolabs/lz-definitions@3.0.68)(zod@3.23.8)
       '@layerzerolabs/devtools-solana': 1.0.6(@layerzerolabs/devtools@0.4.5(@ethersproject/bytes@5.7.0)(@layerzerolabs/io-devtools@0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8))(@layerzerolabs/lz-definitions@3.0.68)(zod@3.23.8))(@layerzerolabs/io-devtools@0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8))(@layerzerolabs/lz-definitions@3.0.68)(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fp-ts@2.16.9)(utf-8-validate@5.0.10)(zod@3.23.8)
       '@layerzerolabs/io-devtools': 0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8)
       '@layerzerolabs/lz-definitions': 3.0.68
-      '@layerzerolabs/lz-solana-sdk-v2': 3.0.0(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)
+      '@layerzerolabs/lz-solana-sdk-v2': 3.0.68(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)
       '@layerzerolabs/lz-v2-utilities': 3.0.18
       '@layerzerolabs/protocol-devtools': 1.1.4(@layerzerolabs/devtools@0.4.5(@ethersproject/bytes@5.7.0)(@layerzerolabs/io-devtools@0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8))(@layerzerolabs/lz-definitions@3.0.68)(zod@3.23.8))(@layerzerolabs/io-devtools@0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8))(@layerzerolabs/lz-definitions@3.0.68)(zod@3.23.8)
       '@layerzerolabs/ua-devtools': 3.0.4(vnend5j44agttyiyihtut5kwuy)
@@ -7832,17 +7729,17 @@ snapshots:
       p-memoize: 4.0.4
       zod: 3.23.8
 
-  '@layerzerolabs/ua-devtools-solana@4.1.0(vouy6yru42fj6xxoh4lnbmwmca)':
+  '@layerzerolabs/ua-devtools-solana@4.1.0(2hnqceym4enum4kywvtggbtboq)':
     dependencies:
       '@layerzerolabs/devtools': 0.4.5(@ethersproject/bytes@5.7.0)(@layerzerolabs/io-devtools@0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8))(@layerzerolabs/lz-definitions@3.0.68)(zod@3.23.8)
       '@layerzerolabs/devtools-solana': 1.0.6(@layerzerolabs/devtools@0.4.5(@ethersproject/bytes@5.7.0)(@layerzerolabs/io-devtools@0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8))(@layerzerolabs/lz-definitions@3.0.68)(zod@3.23.8))(@layerzerolabs/io-devtools@0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8))(@layerzerolabs/lz-definitions@3.0.68)(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fp-ts@2.16.9)(utf-8-validate@5.0.10)(zod@3.23.8)
       '@layerzerolabs/io-devtools': 0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8)
       '@layerzerolabs/lz-definitions': 3.0.68
-      '@layerzerolabs/lz-solana-sdk-v2': 3.0.0(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)
+      '@layerzerolabs/lz-solana-sdk-v2': 3.0.68(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)
       '@layerzerolabs/lz-v2-utilities': 3.0.18
       '@layerzerolabs/oft-v2-solana-sdk': 3.0.68(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)
       '@layerzerolabs/protocol-devtools': 1.1.4(@layerzerolabs/devtools@0.4.5(@ethersproject/bytes@5.7.0)(@layerzerolabs/io-devtools@0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8))(@layerzerolabs/lz-definitions@3.0.68)(zod@3.23.8))(@layerzerolabs/io-devtools@0.1.15(ink-gradient@2.0.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink-table@3.1.0(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2))(ink@3.2.0(bufferutil@4.0.8)(react@17.0.2)(utf-8-validate@5.0.10))(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.23.8))(@layerzerolabs/lz-definitions@3.0.68)(zod@3.23.8)
-      '@layerzerolabs/protocol-devtools-solana': 4.0.7(k67kjvmewxl2uheutlxyqujtmi)
+      '@layerzerolabs/protocol-devtools-solana': 4.0.7(ftdsdl3eqw6hg273iinzxq7cge)
       '@layerzerolabs/ua-devtools': 3.0.4(vnend5j44agttyiyihtut5kwuy)
       '@safe-global/api-kit': 1.3.1
       '@safe-global/protocol-kit': 1.3.0(bufferutil@4.0.8)(ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
@@ -7908,18 +7805,6 @@ snapshots:
       tweetnacl: 1.0.3
       tweetnacl-util: 0.15.1
 
-  '@metaplex-foundation/beet-solana@0.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@metaplex-foundation/beet': 0.7.2
-      '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      bs58: 5.0.0
-      debug: 4.3.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   '@metaplex-foundation/beet-solana@0.4.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@metaplex-foundation/beet': 0.7.2
@@ -7949,34 +7834,6 @@ snapshots:
   '@metaplex-foundation/mpl-toolbox@0.9.4(@metaplex-foundation/umi@0.9.2)':
     dependencies:
       '@metaplex-foundation/umi': 0.9.2
-
-  '@metaplex-foundation/rustbin@0.3.5':
-    dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
-      semver: 7.6.3
-      text-table: 0.2.0
-      toml: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@metaplex-foundation/solita@0.20.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@metaplex-foundation/beet': 0.7.2
-      '@metaplex-foundation/beet-solana': 0.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@metaplex-foundation/rustbin': 0.3.5
-      '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      ansi-colors: 4.1.3
-      camelcase: 6.3.0
-      debug: 4.3.7(supports-color@8.1.1)
-      js-sha256: 0.9.0
-      prettier: 2.8.8
-      snake-case: 3.0.4
-      spok: 1.5.5
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
 
   '@metaplex-foundation/umi-bundle-defaults@0.9.2(@metaplex-foundation/umi@0.9.2)(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
@@ -9715,8 +9572,6 @@ snapshots:
 
   commander@2.20.3: {}
 
-  commander@5.1.0: {}
-
   commander@8.3.0: {}
 
   concat-map@0.0.1: {}
@@ -10665,14 +10520,6 @@ snapshots:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  find-process@1.4.7:
-    dependencies:
-      chalk: 4.1.2
-      commander: 5.1.0
-      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13120,13 +12967,6 @@ snapshots:
   spdx-license-ids@3.0.20: {}
 
   split2@4.2.0: {}
-
-  spok@1.5.5:
-    dependencies:
-      ansicolors: 0.3.2
-      find-process: 1.4.7
-    transitivePeerDependencies:
-      - supports-color
 
   sprintf-js@1.0.3: {}
 


### PR DESCRIPTION
## Summary
- Upgrade DVN configuration from 1/1 (single DVN) to 3/3 (three required DVNs) across all connections
- Add **Nethermind** and **Horizen** as required DVNs alongside **LayerZero Labs** on all 7 chains (Ethereum, Linea, Base, zkSync, Mantle, Sonic, Solana)
- All 84 `requiredDVNs` arrays now contain 3 entries

## DVN Addresses

### Nethermind
| Chain | Address |
|-------|---------|
| Ethereum | `0xa59ba433ac34d2927232918ef5b2eaafcf130ba5` |
| Linea | `0xdd7b5e1db4aafd5c8ec3b764efb8ed265aa5445b` |
| Base | `0x658947bc7956aea0067a62cf87ab02ae199ef3f3` |
| zkSync | `0xb183c2b91cf76cad13602b32ada2fd273f19009c` |
| Mantle | `0xb19a9370d404308040a9760678c8ca28affbbb76` |
| Sonic | `0x05aaefdf9db6e0f7d27fa3b6ee099edb33da029e` |
| Solana | `GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab` |

### Horizen
| Chain | Address |
|-------|---------|
| Ethereum | `0x380275805876ff19055ea900cdb2b46a94ecf20d` |
| Linea | `0x7fe673201724925b5c477d4e1a4bd3e954688cf5` |
| Base | `0xa7b5189bca84cd304d8553977c7c614329750d99` |
| zkSync | `0x1253e268bc04bb43cb96d2f7ee858b8a1433cf6d` |
| Mantle | `0x7fe673201724925b5c477d4e1a4bd3e954688cf5` |
| Sonic | `0x54dd79f5ce72b51fcbbcb170dd01e32034323565` |
| Solana | `HR9NQKK1ynW9NzgdM37dU5CBtqRHTukmbMKS7qkwSkHX` |

Addresses sourced from [LayerZero DVN metadata API](https://metadata.layerzero-api.com/v1/metadata/dvns).

## Test plan
- [ ] Verify DVN addresses match LayerZero's official metadata
- [ ] Run `npx hardhat lz:oapp:config:check --oapp-config layerzero.config.prod.ts` to validate config
- [ ] Deploy config changes via `npx hardhat lz:oapp:wire --oapp-config layerzero.config.prod.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)